### PR TITLE
Major refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Use a multi-stage build to reduce final image size
+FROM python:3.9-slim as builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libasound2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy only what's needed for installing dependencies
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --user -r requirements.txt
+
+# Runtime stage
+FROM python:3.9-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libasound2 \
+    alsa-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy Python dependencies from builder
+COPY --from=builder /root/.local /root/.local
+
+# Copy application files from local directory
+COPY home-assistant-mqtt-volume-control.py .
+COPY configuration.yaml .
+
+# Make sure scripts in .local are usable
+ENV PATH=/root/.local/bin:$PATH
+
+# Volume for configuration (if you want to mount it at runtime instead)
+VOLUME /app/config
+
+# Set the entrypoint to your specific script
+ENTRYPOINT ["python", "home-assistant-mqtt-volume-control.py"]

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -4,8 +4,9 @@ mqtt: #this config only supports one ALSA device - if more than one is needed, c
   port: 1883  #port of the MQTT server - probably want to leave this at the default setting of: 1883
   user: mqtt-username   #username for MQTT server
   password: mqtt-password   #password for MQTT server
-  prefix: homeassistant   #first prefix for MQTT commands - probably want to leave this at the default setting of: homeassistant
+  discover_prefix: homeassistant   #MQTT Discovery root topic prefix. Default value is usually 'homeassistant'
   friendly_name: 'Speaker 1'  #name that will show up on the Home Assistant auto generated entity
+  prefix: '' #Arbitrary prefix to precede 'device_prefix' in topic. Can be set to empty string if you want the base topic to start with the content of 'device_prefix'
   device_prefix: 'smartspeaker'   #second prefix for device config MQTT string - must be all lower-case and no spaces or numbers
   device_name: 'SmartSpeaker'   #device name that is used for Home Assistant Devices
   device_manufacturer: 'SmartSpeaker'   #device manufacturer name that is used for Home Assistant Devices

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  mqtt-volume-control:
+    build: .
+    container_name: mqtt-volume-control
+    restart: unless-stopped
+    devices:
+      - "/dev/snd:/dev/snd"  # Required for ALSA audio control
+    volumes:
+      - ./configuration.yaml:/app/configuration.yaml  # Mount config file
+      - /etc/localtime:/etc/localtime:ro  # Sync time with host
+    environment:
+      - TZ=America/New_York  # Set your timezone

--- a/home-assistant-mqtt-volume-control.py
+++ b/home-assistant-mqtt-volume-control.py
@@ -3,7 +3,8 @@ import time
 import paho.mqtt.client as mqtt
 import yaml
 import math
-
+import signal
+import sys
 import alsaaudio
 
 #sudo apt-get install python3-pip
@@ -16,153 +17,174 @@ import alsaaudio
 default_volume = 80
 DEFAULT_PUBLISH_INTERVAL = 5  # default seconds between volume publishes
 
+# Global flag for graceful shutdown
+shutdown_flag = False
+
+# Signal handler for graceful shutdown
+def signal_handler(sig, frame):
+    global shutdown_flag
+    print("\nReceived shutdown signal, cleaning up...")
+    shutdown_flag = True
+
+# Register signal handlers
+signal.signal(signal.SIGINT, signal_handler)
+signal.signal(signal.SIGTERM, signal_handler)
+
 # Generic class to control audio volumes
 class VolumeControl:
+    def __init__(self, device_id):
+        self.id = device_id
+        self.volume_topic = str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)
+        self.last_publish_time = 0
+        self.publish_interval = config['mqtt'].get('publish_interval', DEFAULT_PUBLISH_INTERVAL)
+        self.periodic_publish_enabled = self.publish_interval > 0
+        
+        if 'default_volume' in config['devices'][self.id]:
+            self.volume_set(config['devices'][self.id]['default_volume'])
+        else:
+            print(self.volume_get())
 
-  def __init__(self, device_id):
-    self.id = device_id
-    self.volume_topic = str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)
-    self.last_publish_time = 0
-    self.publish_interval = config['mqtt'].get('publish_interval', DEFAULT_PUBLISH_INTERVAL)
-    self.periodic_publish_enabled = self.publish_interval > 0
+    def publish_current_volume(self):
+        if not self.periodic_publish_enabled:
+            return
+            
+        current_time = time.time()
+        if current_time - self.last_publish_time >= self.publish_interval:
+            current_volume = self.volume_get()
+            mqttc.publish(self.volume_topic + '/state', current_volume)
+            self.last_publish_time = current_time
     
-    if 'default_volume' in config['devices'][self.id]:
-      self.volume_set(config['devices'][self.id]['default_volume'])
-    else:
-      print(self.volume_get())
+    def volume_get(self):
+        print("Getting Volume from AlsaMixer")
+        card_number = config['devices'][self.id]['alsa_number']
+        control_name = config['devices'][self.id]['control_name'] #this can be found using "amixer -c <card_number>" - the name will appear after the "Simple mixer control" heading
+        try:
+            mixer = alsaaudio.Mixer(control_name,0,card_number)
+        except Exception:
+            mixer = alsaaudio.Mixer('Master',0,card_number)
+            pass 
+        get_volume = mixer.getvolume()
+        get_volume = int(get_volume[0])
+        return get_volume    
+    
+    def volume_set(self,volume):
+        self.volume = volume
+        card_number = config['devices'][self.id]['alsa_number'] #this is the alsa number
+        control_name = config['devices'][self.id]['control_name'] #this can be found using "amixer -c <card_number>" - the name will appear after the "Simple mixer control" heading
+        try:
+            mixer = alsaaudio.Mixer(control_name,0,card_number)
+        except Exception:
+            mixer = alsaaudio.Mixer('Master',0,card_number)
+            pass 
+        print("Setting volume to:",self.volume)    
+        mixer.setvolume(self.volume) 
+        mqttc.publish(self.volume_topic + '/state', self.volume)
+        self.last_publish_time = time.time()
 
-  def publish_current_volume(self):
-    if not self.periodic_publish_enabled:
-      return
-      
-    current_time = time.time()
-    if current_time - self.last_publish_time >= self.publish_interval:
-      current_volume = self.volume_get()
-      mqttc.publish(self.volume_topic + '/state', current_volume)
-      self.last_publish_time = current_time
-  
-  def volume_get(self):
-    print("Getting Volume from AlsaMixer")
-    card_number = config['devices'][self.id]['alsa_number']
-    control_name = config['devices'][self.id]['control_name'] #this can be found using "amixer -c <card_number>" - the name will appear after the "Simple mixer control" heading
-    try:
-        mixer = alsaaudio.Mixer(control_name,0,card_number)
-    except Exception:
-        mixer = alsaaudio.Mixer('Master',0,card_number)
-        pass 
-    get_volume = mixer.getvolume()
-    get_volume = int(get_volume[0])
-    return get_volume    
-  
-  def volume_set(self,volume):
-    self.volume = volume
-    card_number = config['devices'][self.id]['alsa_number'] #this is the alsa number
-    control_name = config['devices'][self.id]['control_name'] #this can be found using "amixer -c <card_number>" - the name will appear after the "Simple mixer control" heading
-    try:
-        mixer = alsaaudio.Mixer(control_name,0,card_number)
-    except Exception:
-        mixer = alsaaudio.Mixer('Master',0,card_number)
-        pass 
-    print("Setting volume to:",self.volume)    
-    mixer.setvolume(self.volume) 
-    mqttc.publish(self.volume_topic + '/state', self.volume)
-    self.last_publish_time = time.time()
+    def volume_up(self):
+        volume = self.volume + 1
+        if volume > 100:
+            volume = 100
+        self.volume_set(volume)
 
-  def volume_up(self):
-    volume = self.volume + 1
-    if volume > 100:
-      volume = 100
-    self.volume_set(volume)
-
-  def volume_down(self):
-    volume = self.volume - 1
-    if volume < 1:
-      volume = 1
-    self.volume_set(volume)
-
+    def volume_down(self):
+        volume = self.volume - 1
+        if volume < 1:
+            volume = 1
+        self.volume_set(volume)
 
 class AlsaVolumeControl(VolumeControl):
-  
-  def __init__(self,id):
-    super().__init__(id)
+    def __init__(self,id):
+        super().__init__(id)
 
 def load_config():
-  # Read the configuration file
-  print("Loading Configuration File...")
-  config_file = open('configuration.yaml', 'r')
-  # Parse the configuration into a dictionary
-  config = yaml.safe_load(config_file)
-  config_file.close
-  print("Configuration Loaded")
-  return config
-  
-def on_connect (client, userdata, flags, rc):
- print("Connected to MQTT with result code", rc)
- mqttc.subscribe(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/set")
- VolumeConfig = "{\"name\": \""+str(friendly_name)+" Volume\", \"uniq_id\":"+str(device_mqtt_id)+"1, \"device\": {\"name\": \""+str(device_name)+"\", \"ids\":"+str(device_mqtt_id)+", \"mf\": \""+str(device_manufacturer)+"\", \"mdl\": \""+str(device_model)+"\", \"sw\": \""+str(device_sw_version)+"\"},\"avty_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability\", \"cmd_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/set\", \"stat_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/state\", \"icon\":\"mdi:volume-high\", \"ret\": \"true\"}"
- mqttc.publish(str(ha_discover_mqtt_prefix)+"/number/"+str(device_prefix)+"/"+str(device_mqtt_id)+"/config",VolumeConfig,0,True)
- mqttc.publish(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability","online",0,True)
- # Publish initial volume state
- for device_id, device in devices.items():
-    current_volume = device.volume_get()
-    mqttc.publish(device.volume_topic + '/state', current_volume)
+    print("Loading Configuration File...")
+    try:
+        with open('configuration.yaml', 'r') as config_file:
+            config = yaml.safe_load(config_file)
+            print("Configuration Loaded")
+            return config
+    except Exception as e:
+        print(f"Error loading configuration: {e}")
+        sys.exit(1)
+
+def on_connect(client, userdata, flags, rc):
+    print("Connected to MQTT with result code", rc)
+    mqttc.subscribe(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/set")
+    VolumeConfig = "{\"name\": \""+str(friendly_name)+" Volume\", \"uniq_id\":"+str(device_mqtt_id)+"1, \"device\": {\"name\": \""+str(device_name)+"\", \"ids\":"+str(device_mqtt_id)+", \"mf\": \""+str(device_manufacturer)+"\", \"mdl\": \""+str(device_model)+"\", \"sw\": \""+str(device_sw_version)+"\"},\"avty_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability\", \"cmd_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/set\", \"stat_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/state\", \"icon\":\"mdi:volume-high\", \"ret\": \"true\"}"
+    mqttc.publish(str(ha_discover_mqtt_prefix)+"/number/"+str(device_prefix)+"/"+str(device_mqtt_id)+"/config",VolumeConfig,0,True)
+    mqttc.publish(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability","online",0,True)
+    # Publish initial volume state
+    for device_id, device in devices.items():
+        current_volume = device.volume_get()
+        mqttc.publish(device.volume_topic + '/state', current_volume)
 
 def on_message(client, userdata, message):
-  print("received message")    
-  payload = str(message.payload.decode("utf-8"))
-  topic = message.topic
-  print(topic + payload)
-  for id, device in devices.items():
-    if topic == device.volume_topic + '/set':
-      if payload == 'UP':
-        device.volume_up()
-      elif payload == 'DOWN':
-        device.volume_down()
-      else:
-        volume = int(payload)
-        if (volume >= 0 and volume <= 100):
-          device.volume_set(volume)
+    print("received message")    
+    payload = str(message.payload.decode("utf-8"))
+    topic = message.topic
+    print(topic + payload)
+    for id, device in devices.items():
+        if topic == device.volume_topic + '/set':
+            if payload == 'UP':
+                device.volume_up()
+            elif payload == 'DOWN':
+                device.volume_down()
+            else:
+                volume = int(payload)
+                if (volume >= 0 and volume <= 100):
+                    device.volume_set(volume)
 
-## Main routine ##
-
-# Load the configuration file
-config = load_config()
-
-device_mqtt_id = config['mqtt']['id']
-device_mqtt_prefix = config['mqtt']['prefix']
-ha_discover_mqtt_prefix = config['mqtt']['discover']
-friendly_name = config['mqtt']['friendly_name']
-device_prefix = config['mqtt']['device_prefix']
-device_name = config['mqtt']['device_name']
-device_manufacturer = config['mqtt']['device_manufacturer']
-device_model = config['mqtt']['device_model']
-device_sw_version = config['mqtt']['device_sw_version']
-
-
-# Initialize the mqtt client
-mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, config['mqtt']['id']) # Create a MQTT client object with the given ID in the configuration
-mqttc.username_pw_set(config['mqtt']['user'], config['mqtt']['password'])
-mqttc.on_connect = on_connect
-mqttc.on_message = on_message
-mqttc.will_set(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability","offline",0,True)
-mqttc.connect(config['mqtt']['host'], config['mqtt']['port'])
-
-
-# Populate the device list
-devices = {}
-for device_id, device_config in config['devices'].items():
-  if device_config['platform'] == 'alsa':
-    devices[device_id] = AlsaVolumeControl(device_id)
-
-# Start MQTT loop in a separate thread
-mqttc.loop_start()
-
-try:
-    while True:
-        for device in devices.values():
-            device.publish_current_volume()
-        time.sleep(1)
-except KeyboardInterrupt:
-    print("Stopping MQTT client...")
+def cleanup():
+    print("Performing cleanup...")
+    # Publish offline status
+    mqttc.publish(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability","offline",0,True)
+    # Disconnect from MQTT
     mqttc.loop_stop()
     mqttc.disconnect()
+    print("Cleanup complete")
+
+## Main routine ##
+if __name__ == "__main__":
+    try:
+        # Load the configuration file
+        config = load_config()
+
+        device_mqtt_id = config['mqtt']['id']
+        device_mqtt_prefix = config['mqtt']['prefix']
+        ha_discover_mqtt_prefix = config['mqtt']['discover']
+        friendly_name = config['mqtt']['friendly_name']
+        device_prefix = config['mqtt']['device_prefix']
+        device_name = config['mqtt']['device_name']
+        device_manufacturer = config['mqtt']['device_manufacturer']
+        device_model = config['mqtt']['device_model']
+        device_sw_version = config['mqtt']['device_sw_version']
+
+        # Initialize the mqtt client
+        mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, config['mqtt']['id'])
+        mqttc.username_pw_set(config['mqtt']['user'], config['mqtt']['password'])
+        mqttc.on_connect = on_connect
+        mqttc.on_message = on_message
+        mqttc.will_set(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability","offline",0,True)
+        mqttc.connect(config['mqtt']['host'], config['mqtt']['port'])
+
+        # Populate the device list
+        devices = {}
+        for device_id, device_config in config['devices'].items():
+            if device_config['platform'] == 'alsa':
+                devices[device_id] = AlsaVolumeControl(device_id)
+
+        # Start MQTT loop in a separate thread
+        mqttc.loop_start()
+
+        print("Service started. Waiting for messages...")
+        while not shutdown_flag:
+            for device in devices.values():
+                device.publish_current_volume()
+            time.sleep(1)
+
+    except Exception as e:
+        print(f"Error in main loop: {e}")
+    finally:
+        cleanup()
+        sys.exit(0)

--- a/home-assistant-mqtt-volume-control.py
+++ b/home-assistant-mqtt-volume-control.py
@@ -5,6 +5,7 @@ import yaml
 import alsaaudio
 import signal
 import sys
+import json
 from typing import Dict, Any, Optional
 
 # Configuration
@@ -148,43 +149,50 @@ def _post_connect_setup(client: mqtt.Client, userdata):
     
     # Home Assistant volume discovery
     volume_discovery_payload = {
-        "name": f"{mqtt_conf['friendly_name']} Volume",
-        "uniq_id": f"{mqtt_conf['id']}_volume",
-        "device": {
-            "name": mqtt_conf['device_name'],
-            "ids": mqtt_conf['id'],
-            "mf": mqtt_conf['device_manufacturer'],
-            "mdl": mqtt_conf['device_model'],
-            "sw": mqtt_conf['device_sw_version']
-        },
-        "avty_t": f"{base_topic}/availability",
-        "cmd_t": f"{base_topic}/volume/set",
-        "stat_t": f"{base_topic}/volume/state",
-        "icon": "mdi:volume-high",
-        "ret": True
+    "name": f"{mqtt_conf['friendly_name']} Volume",
+    "uniq_id": f"{mqtt_conf['id']}_volume",
+    "device": {
+        "name": mqtt_conf['device_name'],
+        "ids": mqtt_conf['id'],
+        "mf": mqtt_conf['device_manufacturer'],
+        "mdl": mqtt_conf['device_model'],
+        "sw": mqtt_conf['device_sw_version']
+    },
+    "avty_t": f"{base_topic}/availability",
+    "cmd_t": f"{base_topic}/volume/set",
+    "stat_t": f"{base_topic}/volume/state",
+    "icon": "mdi:volume-high",
+    "ret": True
     }
-    client.publish(f"{mqtt_conf['discover_prefix']}/number/{mqtt_conf['device_prefix']}/{mqtt_conf['id']}_volume/config", 
-                  str(volume_discovery_payload), retain=True)
+    client.publish(
+        f"{mqtt_conf['discover_prefix']}/number/{mqtt_conf['device_prefix']}/{mqtt_conf['id']}_volume/config",
+        json.dumps(volume_discovery_payload),  # Use json.dumps() instead of str()
+        retain=True
+)
+
     
     # Home Assistant mute discovery
     mute_discovery_payload = {
-        "name": f"{mqtt_conf['friendly_name']} Mute",
-        "uniq_id": f"{mqtt_conf['id']}_mute",
-        "device": {
-            "name": mqtt_conf['device_name'],
-            "ids": mqtt_conf['id'],
-            "mf": mqtt_conf['device_manufacturer'],
-            "mdl": mqtt_conf['device_model'],
-            "sw": mqtt_conf['device_sw_version']
-        },
-        "avty_t": f"{base_topic}/availability",
-        "cmd_t": f"{base_topic}/mute/set",
-        "stat_t": f"{base_topic}/mute/state",
-        "icon": "mdi:speaker-mute",
-        "ret": True
+    "name": f"{mqtt_conf['friendly_name']} Mute",
+    "uniq_id": f"{mqtt_conf['id']}_mute",
+    "device": {
+        "name": mqtt_conf['device_name'],
+        "ids": mqtt_conf['id'],
+        "mf": mqtt_conf['device_manufacturer'],
+        "mdl": mqtt_conf['device_model'],
+        "sw": mqtt_conf['device_sw_version']
+    },
+    "avty_t": f"{base_topic}/availability",
+    "cmd_t": f"{base_topic}/mute/set",
+    "stat_t": f"{base_topic}/mute/state",
+    "icon": "mdi:speaker-mute",
+    "ret": True
     }
-    client.publish(f"{mqtt_conf['discover_prefix']}/switch/{mqtt_conf['device_prefix']}/{mqtt_conf['id']}_mute/config", 
-                  str(mute_discovery_payload), retain=True)
+    client.publish(
+        f"{mqtt_conf['discover_prefix']}/switch/{mqtt_conf['device_prefix']}/{mqtt_conf['id']}_mute/config",
+        json.dumps(mute_discovery_payload),  # Use json.dumps() here too
+        retain=True
+    )
     
     # Publish initial states
     for device in userdata['devices'].values():
@@ -292,7 +300,7 @@ def main():
         print("Service started. Waiting for messages...")
         while not shutdown_flag:
             for device in devices.values():
-                device.publish_current_volume()
+                device.publish_current_state()
             time.sleep(1)
             
     except Exception as e:

--- a/home-assistant-mqtt-volume-control.py
+++ b/home-assistant-mqtt-volume-control.py
@@ -2,189 +2,234 @@
 import time
 import paho.mqtt.client as mqtt
 import yaml
-import math
+import alsaaudio
 import signal
 import sys
-import alsaaudio
+from typing import Dict, Any, Optional
 
-#sudo apt-get install python3-pip
-#sudo pip3 install paho-mqtt
-#sudo apt-get install python3-yaml, sudo pip3 install pyyaml
-#sudo apt-get install libasound2-dev, sudo apt-get install python3-dev, sudo apt-get install alsa-utils 
-#sudo pip3 install pyalsaaudio
-
-# Initial volume for devices that don't override this in their config:
-default_volume = 80
-DEFAULT_PUBLISH_INTERVAL = 5  # default seconds between volume publishes
-
-# Global flag for graceful shutdown
+# Configuration
+DEFAULT_VOLUME = 80
+DEFAULT_PUBLISH_INTERVAL = 5  # seconds
 shutdown_flag = False
 
-# Signal handler for graceful shutdown
-def signal_handler(sig, frame):
-    global shutdown_flag
-    print("\nReceived shutdown signal, cleaning up...")
-    shutdown_flag = True
-
-# Register signal handlers
-signal.signal(signal.SIGINT, signal_handler)
-signal.signal(signal.SIGTERM, signal_handler)
-
-# Generic class to control audio volumes
 class VolumeControl:
-    def __init__(self, device_id):
+    def __init__(self, device_id: str, config: Dict[str, Any], mqtt_client: mqtt.Client):
         self.id = device_id
-        self.volume_topic = str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)
-        self.last_publish_time = 0
-        self.publish_interval = config['mqtt'].get('publish_interval', DEFAULT_PUBLISH_INTERVAL)
+        self.config = config
+        self.mqttc = mqtt_client
+        mqtt_conf = config['mqtt']
+        self.volume_topic = f"{mqtt_conf['prefix']}{mqtt_conf['device_prefix']}/{mqtt_conf['id']}"
+        self.publish_interval = mqtt_conf.get('publish_interval', DEFAULT_PUBLISH_INTERVAL)
         self.periodic_publish_enabled = self.publish_interval > 0
+        self.last_publish_time = 0
         
-        if 'default_volume' in config['devices'][self.id]:
-            self.volume_set(config['devices'][self.id]['default_volume'])
-        else:
-            print(self.volume_get())
+        # Initialize volume
+        self.volume = self.volume_get()
+        if 'default_volume' in config['devices'][device_id]:
+            self.volume_set(config['devices'][device_id]['default_volume'])
 
-    def publish_current_volume(self):
-        if not self.periodic_publish_enabled:
+    def publish_current_volume(self) -> None:
+        if not self.periodic_publish_enabled or shutdown_flag:
             return
             
         current_time = time.time()
         if current_time - self.last_publish_time >= self.publish_interval:
             current_volume = self.volume_get()
-            mqttc.publish(self.volume_topic + '/state', current_volume)
+            self._mqtt_publish(f"{self.volume_topic}/state", current_volume)
             self.last_publish_time = current_time
     
-    def volume_get(self):
-        print("Getting Volume from AlsaMixer")
-        card_number = config['devices'][self.id]['alsa_number']
-        control_name = config['devices'][self.id]['control_name'] #this can be found using "amixer -c <card_number>" - the name will appear after the "Simple mixer control" heading
+    def volume_get(self) -> int:
+        card_number = self.config['devices'][self.id]['alsa_number']
+        control_name = self.config['devices'][self.id].get('control_name', 'Master')
+        
         try:
-            mixer = alsaaudio.Mixer(control_name,0,card_number)
-        except Exception:
-            mixer = alsaaudio.Mixer('Master',0,card_number)
-            pass 
-        get_volume = mixer.getvolume()
-        get_volume = int(get_volume[0])
-        return get_volume    
+            mixer = alsaaudio.Mixer(control_name, 0, card_number)
+            return int(mixer.getvolume()[0])
+        except alsaaudio.ALSAAudioError:
+            print(f"Failed to get volume for {control_name}, trying Master...")
+            mixer = alsaaudio.Mixer('Master', 0, card_number)
+            return int(mixer.getvolume()[0])
     
-    def volume_set(self,volume):
+    def volume_set(self, volume: int) -> None:
         self.volume = volume
-        card_number = config['devices'][self.id]['alsa_number'] #this is the alsa number
-        control_name = config['devices'][self.id]['control_name'] #this can be found using "amixer -c <card_number>" - the name will appear after the "Simple mixer control" heading
+        card_number = self.config['devices'][self.id]['alsa_number']
+        control_name = self.config['devices'][self.id].get('control_name', 'Master')
+        
         try:
-            mixer = alsaaudio.Mixer(control_name,0,card_number)
-        except Exception:
-            mixer = alsaaudio.Mixer('Master',0,card_number)
-            pass 
-        print("Setting volume to:",self.volume)    
-        mixer.setvolume(self.volume) 
-        mqttc.publish(self.volume_topic + '/state', self.volume)
+            mixer = alsaaudio.Mixer(control_name, 0, card_number)
+            mixer.setvolume(volume)
+        except alsaaudio.ALSAAudioError:
+            mixer = alsaaudio.Mixer('Master', 0, card_number)
+            mixer.setvolume(volume)
+            
+        self._mqtt_publish(f"{self.volume_topic}/state", volume)
         self.last_publish_time = time.time()
 
-    def volume_up(self):
-        volume = self.volume + 1
-        if volume > 100:
-            volume = 100
-        self.volume_set(volume)
+    def _mqtt_publish(self, topic: str, payload, retain: bool = True) -> None:
+        """Wrapper for MQTT publish with version compatibility"""
+        if hasattr(self.mqttc, 'publish') and callable(self.mqttc.publish):
+            self.mqttc.publish(topic, payload, retain=retain)
 
-    def volume_down(self):
-        volume = self.volume - 1
-        if volume < 1:
-            volume = 1
-        self.volume_set(volume)
+    def volume_up(self) -> None:
+        self.volume_set(min(self.volume + 1, 100))
 
-class AlsaVolumeControl(VolumeControl):
-    def __init__(self,id):
-        super().__init__(id)
+    def volume_down(self) -> None:
+        self.volume_set(max(self.volume - 1, 1))
 
-def load_config():
-    print("Loading Configuration File...")
+def signal_handler(sig, frame):
+    global shutdown_flag
+    print("\nReceived shutdown signal, cleaning up...")
+    shutdown_flag = True
+
+def load_config() -> Dict[str, Any]:
     try:
         with open('configuration.yaml', 'r') as config_file:
-            config = yaml.safe_load(config_file)
-            print("Configuration Loaded")
-            return config
+            return yaml.safe_load(config_file)
     except Exception as e:
         print(f"Error loading configuration: {e}")
         sys.exit(1)
 
-def on_connect(client, userdata, flags, rc):
-    print("Connected to MQTT with result code", rc)
-    mqttc.subscribe(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/set")
-    VolumeConfig = "{\"name\": \""+str(friendly_name)+" Volume\", \"uniq_id\":"+str(device_mqtt_id)+"1, \"device\": {\"name\": \""+str(device_name)+"\", \"ids\":"+str(device_mqtt_id)+", \"mf\": \""+str(device_manufacturer)+"\", \"mdl\": \""+str(device_model)+"\", \"sw\": \""+str(device_sw_version)+"\"},\"avty_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability\", \"cmd_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/set\", \"stat_t\": \""+str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/state\", \"icon\":\"mdi:volume-high\", \"ret\": \"true\"}"
-    mqttc.publish(str(ha_discover_mqtt_prefix)+"/number/"+str(device_prefix)+"/"+str(device_mqtt_id)+"/config",VolumeConfig,0,True)
-    mqttc.publish(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability","online",0,True)
-    # Publish initial volume state
-    for device_id, device in devices.items():
-        current_volume = device.volume_get()
-        mqttc.publish(device.volume_topic + '/state', current_volume)
+def on_connect_v3(client: mqtt.Client, userdata, flags, rc):
+    """MQTT v3.1.1 connection callback"""
+    if rc != 0:
+        print(f"Failed to connect: {mqtt.connack_string(rc)}")
+        return
+        
+    print(f"Connected to MQTT with result code {rc} ({mqtt.connack_string(rc)})")
+    _post_connect_setup(client, userdata)
+
+def on_connect_v5(client: mqtt.Client, userdata, flags, reason_code, properties):
+    """MQTT v5.0 connection callback"""
+    if reason_code.is_failure:
+        print(f"Failed to connect: {reason_code}")
+        return
+        
+    print(f"Connected to MQTT with result code {reason_code}")
+    _post_connect_setup(client, userdata)
+
+def _post_connect_setup(client: mqtt.Client, userdata):
+    """Common post-connection setup for both MQTT versions"""
+    config = userdata['config']
+    mqtt_conf = config['mqtt']
+    
+    # Subscribe to control topic
+    topic = f"{mqtt_conf['prefix']}{mqtt_conf['device_prefix']}/{mqtt_conf['id']}/set"
+    client.subscribe(topic)
+    
+    # Home Assistant discovery
+    discovery_topic = f"{mqtt_conf['discover']}/number/{mqtt_conf['device_prefix']}/{mqtt_conf['id']}/config"
+    discovery_payload = {
+        "name": f"{mqtt_conf['friendly_name']} Volume",
+        "uniq_id": f"{mqtt_conf['id']}1",
+        "device": {
+            "name": mqtt_conf['device_name'],
+            "ids": mqtt_conf['id'],
+            "mf": mqtt_conf['device_manufacturer'],
+            "mdl": mqtt_conf['device_model'],
+            "sw": mqtt_conf['device_sw_version']
+        },
+        "avty_t": f"{mqtt_conf['prefix']}{mqtt_conf['device_prefix']}/{mqtt_conf['id']}/availability",
+        "cmd_t": f"{mqtt_conf['prefix']}{mqtt_conf['device_prefix']}/{mqtt_conf['id']}/set",
+        "stat_t": f"{mqtt_conf['prefix']}{mqtt_conf['device_prefix']}/{mqtt_conf['id']}/state",
+        "icon": "mdi:volume-high",
+        "ret": True
+    }
+    client.publish(discovery_topic, str(discovery_payload), retain=True)
+    client.publish(f"{mqtt_conf['prefix']}{mqtt_conf['device_prefix']}/{mqtt_conf['id']}/availability", "online", retain=True)
 
 def on_message(client, userdata, message):
-    print("received message")    
-    payload = str(message.payload.decode("utf-8"))
-    topic = message.topic
-    print(topic + payload)
-    for id, device in devices.items():
-        if topic == device.volume_topic + '/set':
-            if payload == 'UP':
-                device.volume_up()
-            elif payload == 'DOWN':
-                device.volume_down()
-            else:
-                volume = int(payload)
-                if (volume >= 0 and volume <= 100):
-                    device.volume_set(volume)
-
-def cleanup():
-    print("Performing cleanup...")
-    # Publish offline status
-    mqttc.publish(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability","offline",0,True)
-    # Disconnect from MQTT
-    mqttc.loop_stop()
-    mqttc.disconnect()
-    print("Cleanup complete")
-
-## Main routine ##
-if __name__ == "__main__":
     try:
-        # Load the configuration file
-        config = load_config()
+        payload = message.payload.decode("utf-8")
+        print(f"Received message on {message.topic}: {payload}")
+        
+        for device in userdata['devices'].values():
+            if message.topic == f"{device.volume_topic}/set":
+                if payload == 'UP':
+                    device.volume_up()
+                elif payload == 'DOWN':
+                    device.volume_down()
+                else:
+                    volume = int(payload)
+                    if 0 <= volume <= 100:
+                        device.volume_set(volume)
+    except Exception as e:
+        print(f"Error processing message: {e}")
 
-        device_mqtt_id = config['mqtt']['id']
-        device_mqtt_prefix = config['mqtt']['prefix']
-        ha_discover_mqtt_prefix = config['mqtt']['discover']
-        friendly_name = config['mqtt']['friendly_name']
-        device_prefix = config['mqtt']['device_prefix']
-        device_name = config['mqtt']['device_name']
-        device_manufacturer = config['mqtt']['device_manufacturer']
-        device_model = config['mqtt']['device_model']
-        device_sw_version = config['mqtt']['device_sw_version']
+def create_mqtt_client(config: Dict[str, Any], use_mqttv5: bool = False) -> mqtt.Client:
+    """Create and configure MQTT client with version detection"""
+    mqtt_conf = config['mqtt']
+    
+    if use_mqttv5:
+        client = mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION2,
+            client_id=mqtt_conf['id'],
+            protocol=mqtt.MQTTv5
+        )
+        client.on_connect = on_connect_v5
+    else:
+        client = mqtt.Client(
+            mqtt.CallbackAPIVersion.VERSION1,
+            client_id=mqtt_conf['id'],
+            protocol=mqtt.MQTTv311
+        )
+        client.on_connect = on_connect_v3
+    
+    client.username_pw_set(mqtt_conf['user'], mqtt_conf['password'])
+    return client
 
-        # Initialize the mqtt client
-        mqttc = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, config['mqtt']['id'])
-        mqttc.username_pw_set(config['mqtt']['user'], config['mqtt']['password'])
-        mqttc.on_connect = on_connect
-        mqttc.on_message = on_message
-        mqttc.will_set(str(device_mqtt_prefix)+str(device_prefix)+"/"+str(device_mqtt_id)+"/availability","offline",0,True)
-        mqttc.connect(config['mqtt']['host'], config['mqtt']['port'])
-
-        # Populate the device list
-        devices = {}
-        for device_id, device_config in config['devices'].items():
-            if device_config['platform'] == 'alsa':
-                devices[device_id] = AlsaVolumeControl(device_id)
-
-        # Start MQTT loop in a separate thread
-        mqttc.loop_start()
-
+def main():
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+    
+    config = load_config()
+    mqtt_conf = config['mqtt']
+    
+    # Try MQTT v5 first, fall back to v3 if not available
+    try:
+        client = create_mqtt_client(config, use_mqttv5=True)
+    except AttributeError:
+        print("MQTT v5 not available, falling back to MQTT v3.1.1")
+        client = create_mqtt_client(config, use_mqttv5=False)
+    
+    # Setup devices
+    devices = {
+        dev_id: VolumeControl(dev_id, config, client)
+        for dev_id, dev_config in config['devices'].items()
+        if dev_config['platform'] == 'alsa'
+    }
+    
+    client.user_data_set({'config': config, 'devices': devices})
+    client.on_message = on_message
+    
+    # Set last will
+    client.will_set(
+        f"{mqtt_conf['prefix']}{mqtt_conf['device_prefix']}/{mqtt_conf['id']}/availability",
+        "offline",
+        retain=True
+    )
+    
+    try:
+        client.connect(mqtt_conf['host'], mqtt_conf['port'])
+        client.loop_start()
+        
         print("Service started. Waiting for messages...")
         while not shutdown_flag:
             for device in devices.values():
                 device.publish_current_volume()
             time.sleep(1)
-
+            
     except Exception as e:
         print(f"Error in main loop: {e}")
     finally:
-        cleanup()
-        sys.exit(0)
+        print("Shutting down...")
+        client.publish(
+            f"{mqtt_conf['prefix']}{mqtt_conf['device_prefix']}/{mqtt_conf['id']}/availability",
+            "offline",
+            retain=True
+        )
+        client.loop_stop()
+        client.disconnect()
+        print("Cleanup complete")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# MQTT client (supports both v2.x with MQTTv5 and v1.6.x with MQTTv3)
+paho-mqtt>=1.6.1
+
+# YAML configuration parsing
+PyYAML>=6.0
+
+# ALSA audio control
+pyalsaaudio>=0.9.0
+
+# Optional typing support for older Python versions
+typing-extensions>=4.0.0 ; python_version < '3.8'

--- a/systemd.unit
+++ b/systemd.unit
@@ -1,0 +1,13 @@
+[Unit]
+Description=ALSA Volume MQTT Publisher
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/python3 /path/to/your/script.py
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Proper support for Paho MQTT v2 with fallback support to version <=1.6.1
- Split HA discovery topic prefix and control topic prefix
  - I don't think creating your actions MQTT topics inside `homeassistant` discovery topic space is the normal way to do things.
- Added mute toggle support
  - Exposed as switch in HA. Discovery entry added
- Initial value publish
- Configurable periodic publish
  - `publish_interval` in configuration.yaml
  - set `publish_interval` to 0 to disable periodic publish
  - Default value of 5 seconds if `publish_interval` is not set in configuration.yaml
- Use pyalsaaudio event poller for near instant state change report to MQTT
- Added sample systemd unit file
- Added Dockerfile for image creation
- Added docker compose file for image building and running